### PR TITLE
Fix interactive notifications: use uint32 instead of int32

### DIFF
--- a/lib/naughty/dbus.lua.in
+++ b/lib/naughty/dbus.lua.in
@@ -52,7 +52,7 @@ local function sendActionInvoked(notificationId, action)
     if capi.dbus then
         capi.dbus.emit_signal("session", "/org/freedesktop/Notifications",
         "org.freedesktop.Notifications", "ActionInvoked",
-        "i", notificationId,
+        "u", notificationId,
         "s", action)
     end
 end
@@ -61,8 +61,8 @@ local function sendNotificationClosed(notificationId, reason)
     if capi.dbus then
         capi.dbus.emit_signal("session", "/org/freedesktop/Notifications",
         "org.freedesktop.Notifications", "NotificationClosed",
-        "i", notificationId,
-        "i", reason)
+        "u", notificationId,
+        "u", reason)
     end
 end
 


### PR DESCRIPTION
Fixes https://github.com/awesomeWM/awesome/issues/259.
Closes https://github.com/awesomeWM/awesome/pull/261.
